### PR TITLE
Use `u64` for PC instead of `isize`

### DIFF
--- a/src/arm64/helper.rs
+++ b/src/arm64/helper.rs
@@ -1,14 +1,14 @@
 use tnj::types::{Type, I32, I64};
 use yaxpeax_arm::armv8::a64::{Operand, SizeCode};
 
-pub fn get_pc_offset_as_int(operand: Operand) -> isize {
+pub fn get_pc_offset_as_int(operand: Operand) -> u64 {
     match operand {
-        Operand::PCOffset(imm) => imm as isize,
+        Operand::PCOffset(imm) => imm as u64,
         op => unimplemented!("dst op {:?}", op),
     }
 }
 
-pub fn get_block_name(jump_address: isize) -> String {
+pub fn get_block_name(jump_address: u64) -> String {
     format!("block_{}", jump_address)
 }
 


### PR DESCRIPTION
By using `isize`, the size of the PC is dependent on which platform we're running on (e.g., on a 32-bit platform, the PC would only be 32 bits large).
By switching to `u64`, we ensure that the program counter is always the correct size. This also means that we need to use `.wrapping_add` for operations that might overflow (e.g. when adding an offset encoded in two's complement).