### PR TITLE
update to latest tnj version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,12 +27,12 @@ dependencies = [
 [[package]]
 name = "air-macros"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 
 [[package]]
 name = "air-meta"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "air-types",
  "convert_case",
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 name = "air-sym"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "air-macros",
  "air-types",
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 name = "air-types"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "num",
 ]
@@ -251,18 +251,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -316,18 +316,18 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "serde"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.215"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -342,9 +342,9 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "syn"
-version = "2.0.90"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -406,7 +406,7 @@ dependencies = [
 [[package]]
 name = "tnj"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "air-macros",
  "air-meta",
@@ -421,7 +421,7 @@ dependencies = [
 [[package]]
 name = "tnj-air"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "air-macros",
  "air-meta",
@@ -440,7 +440,7 @@ dependencies = [
 [[package]]
 name = "tnj-arch"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "air-macros",
  "air-types",
@@ -451,7 +451,7 @@ dependencies = [
 [[package]]
 name = "tnj-pcc"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "air-sym",
  "air-types",
@@ -465,7 +465,7 @@ dependencies = [
 [[package]]
 name = "tnj-policy"
 version = "0.3.0"
-source = "git+ssh://git@github.com/TUM-DSE/tnj.git?rev=28b2b8c51110a017d8a50edc96cfce3257e99631#28b2b8c51110a017d8a50edc96cfce3257e99631"
+source = "git+ssh://git@github.com/TUM-DSE/tnj.git?branch=main#f516cbc1e169eacd591859d321fc7e2f96ae58ac"
 dependencies = [
  "air-sym",
  "air-types",
@@ -480,9 +480,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "11cd88e12b17c6494200a9c1b683a04fcac9573ed74cd1b62aeb2727c5592243"
 
 [[package]]
 name = "unicode-segmentation"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,6 @@ elf = "0.7.4"
 filecheck = "0.5.0"
 target-lexicon = "0.13.1"
 thiserror = "2.0.0"
-tnj = { git = "ssh://git@github.com/TUM-DSE/tnj.git", rev = "28b2b8c51110a017d8a50edc96cfce3257e99631" }
+tnj = { git = "ssh://git@github.com/TUM-DSE/tnj.git", branch = "main" }
 yaxpeax-arch = "0.3.2"
 yaxpeax-arm = "0.3.0"

--- a/src/arm64/label_resolver.rs
+++ b/src/arm64/label_resolver.rs
@@ -4,8 +4,8 @@ use std::cmp::Reverse;
 use std::collections::HashMap;
 use std::collections::{BinaryHeap, HashSet};
 use std::hash::Hash;
+use tnj::air::instructions::builder::InstructionBuilder;
 use tnj::air::instructions::BasicBlock;
-use tnj::air::instructions::{builder::InstructionBuilder, BlockParamData};
 use yaxpeax_arch::{Decoder, U8Reader};
 use yaxpeax_arm::armv8::a64::{DecodeError, InstDecoder, Opcode};
 
@@ -129,7 +129,7 @@ impl LabelResolver {
                 None => break,
             };
             let name = helper::get_block_name(checkpoint);
-            let b = builder.create_block(name.clone(), Vec::<BlockParamData>::new());
+            let b = builder.create_block(name.clone(), []);
             self.blocks.insert(name, b);
         }
     }

--- a/src/arm64/lifter.rs
+++ b/src/arm64/lifter.rs
@@ -5,7 +5,7 @@ use crate::Lifter;
 use target_lexicon::{Aarch64Architecture, Architecture};
 use thiserror::Error;
 use tnj::air::instructions::builder::InstructionBuilder;
-use tnj::air::instructions::{Blob, BlockParamData, Inst, Value};
+use tnj::air::instructions::{Blob, Inst, Value};
 use tnj::arch::get_arch;
 use tnj::arch::reg::Reg;
 use tnj::types::{Type, BOOL, I1, I128, I16, I32, I64, I8};
@@ -118,7 +118,7 @@ impl Lifter for AArch64Lifter {
                             let (dst_reg, _) = Self::get_dst_reg(&builder, inst);
                             let offset = Self::get_value(&mut builder, inst.operands[1]);
                             let reverse_mask = builder.iconst(0xFFF);
-                            let mask = builder.not(reverse_mask, I64);
+                            let mask = builder.bitwise_not(reverse_mask, I64);
                             let pc = Self::get_pc(&mut builder);
                             let masked_pc = builder.and(pc, mask, I64);
                             let addr = builder.add(masked_pc, offset, I64);
@@ -188,14 +188,10 @@ impl Lifter for AArch64Lifter {
                             );
                         }
                         Opcode::BFM => {
-                            let positive_condition_block = builder.create_block(
-                                "bfm_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "bfm_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("bfm_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("bfm_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -227,7 +223,7 @@ impl Lifter for AArch64Lifter {
                             // clear dst bits that are replaced by the src bitfield
                             let dst_mask = builder.lshl(one, src_bitfield_size, op_type);
                             let dst_mask = builder.sub(dst_mask, one, op_type);
-                            let dst_mask = builder.not(dst_mask, op_type);
+                            let dst_mask = builder.bitwise_not(dst_mask, op_type);
                             let dst_bitfield = builder.and(src, dst_mask, op_type);
                             // merge and write bitfield
                             let val = builder.or(src_bitfield, dst_bitfield, op_type);
@@ -252,7 +248,7 @@ impl Lifter for AArch64Lifter {
                             let dst_mask = builder.lshl(one, src_bitfield_size, op_type);
                             let dst_mask = builder.sub(dst_mask, one, op_type);
                             let dst_mask = builder.lshl(dst_mask, starting_position, op_type);
-                            let dst_mask = builder.not(dst_mask, op_type);
+                            let dst_mask = builder.bitwise_not(dst_mask, op_type);
                             let dst_bitfield = builder.and(src, dst_mask, op_type);
                             // merge and write bitfield
                             let val = builder.or(src_bitfield, dst_bitfield, op_type);
@@ -264,7 +260,7 @@ impl Lifter for AArch64Lifter {
                             let src2 = Self::get_value(&mut builder, inst.operands[2]);
                             let (dst_reg, sz) = Self::get_dst_reg(&builder, inst);
                             let op_type = helper::get_type_by_sizecode(sz);
-                            let neg_src2 = builder.not(src2, op_type);
+                            let neg_src2 = builder.bitwise_not(src2, op_type);
                             let val = builder.and(src1, neg_src2, op_type);
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                         }
@@ -281,8 +277,7 @@ impl Lifter for AArch64Lifter {
                         }
                         Opcode::CAS(_memory_ordering) => {
                             // Untested
-                            let swap_block =
-                                builder.create_block("cas_swap", Vec::<BlockParamData>::new());
+                            let swap_block = builder.create_block("cas_swap", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -334,14 +329,10 @@ impl Lifter for AArch64Lifter {
                             builder.jumpif(condition, *block, Vec::new(), next_block, Vec::new());
                         }
                         Opcode::CCMN => {
-                            let positive_condition_block = builder.create_block(
-                                "ccmp_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "ccmp_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("ccmp_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("ccmp_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -369,14 +360,10 @@ impl Lifter for AArch64Lifter {
                             builder.jump(next_block, Vec::new());
                         }
                         Opcode::CCMP => {
-                            let positive_condition_block = builder.create_block(
-                                "ccmp_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "ccmp_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("ccmp_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("ccmp_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -394,7 +381,7 @@ impl Lifter for AArch64Lifter {
                             builder.set_insert_block(positive_condition_block);
                             let src1 = Self::get_value(&mut builder, inst.operands[0]);
                             let src2 = Self::get_value(&mut builder, inst.operands[1]);
-                            let not_src2 = builder.not(src2, op_type);
+                            let not_src2 = builder.bitwise_not(src2, op_type);
                             let carry = builder.iconst(0);
                             Self::set_flags_using_adc(
                                 &mut builder,
@@ -418,7 +405,7 @@ impl Lifter for AArch64Lifter {
                             let one = builder.iconst(1);
                             let val1 = builder.lshr(src, one, op_type);
                             let val2_mask = builder.ror(one, one, op_type);
-                            let val2_mask = builder.not(val2_mask, op_type);
+                            let val2_mask = builder.bitwise_not(val2_mask, op_type);
                             let val2 = builder.and(val2_mask, src, op_type);
                             let val = builder.xor(val1, val2, op_type);
 
@@ -449,14 +436,10 @@ impl Lifter for AArch64Lifter {
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                         }
                         Opcode::CSEL => {
-                            let positive_condition_block = builder.create_block(
-                                "csel_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "csel_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("csel_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("csel_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -482,14 +465,10 @@ impl Lifter for AArch64Lifter {
                             builder.jump(next_block, Vec::new());
                         }
                         Opcode::CSINC => {
-                            let positive_condition_block = builder.create_block(
-                                "csinc_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "csinc_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("csinc_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("csinc_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -519,14 +498,10 @@ impl Lifter for AArch64Lifter {
                             builder.jump(next_block, Vec::new());
                         }
                         Opcode::CSINV => {
-                            let positive_condition_block = builder.create_block(
-                                "csinv_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "csinv_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("csinv_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("csinv_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -550,19 +525,15 @@ impl Lifter for AArch64Lifter {
                             // Condition is false
                             builder.set_insert_block(negative_condition_block);
                             let src2 = Self::get_value(&mut builder, inst.operands[2]);
-                            let val = builder.not(src2, op_type);
+                            let val = builder.bitwise_not(src2, op_type);
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                             builder.jump(next_block, Vec::new());
                         }
                         Opcode::CSNEG => {
-                            let positive_condition_block = builder.create_block(
-                                "csneg_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "csneg_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("csneg_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("csneg_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -597,7 +568,7 @@ impl Lifter for AArch64Lifter {
                             let (dst_reg, sz) = Self::get_dst_reg(&builder, inst);
                             let op_type = helper::get_type_by_sizecode(sz);
 
-                            let src2 = builder.not(src2, op_type);
+                            let src2 = builder.bitwise_not(src2, op_type);
                             let val = builder.xor(src1, src2, op_type);
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                         }
@@ -763,7 +734,7 @@ impl Lifter for AArch64Lifter {
                             Self::write_reg(&mut builder, zero, dst_reg, op_type);
 
                             let src = Self::get_value(&mut builder, inst.operands[1]);
-                            let src = builder.not(src, I16);
+                            let src = builder.bitwise_not(src, I16);
                             Self::write_reg(&mut builder, src, dst_reg, I16);
                         }
                         Opcode::MOVZ => {
@@ -798,7 +769,7 @@ impl Lifter for AArch64Lifter {
                             let op_type = helper::get_type_by_sizecode(sz);
                             let src1 = Self::get_value(&mut builder, inst.operands[1]);
                             let src2 = Self::get_value(&mut builder, inst.operands[2]);
-                            let val = builder.not(src2, op_type);
+                            let val = builder.bitwise_not(src2, op_type);
                             let val = builder.or(src1, val, op_type);
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                         }
@@ -880,7 +851,7 @@ impl Lifter for AArch64Lifter {
                             let src1 = Self::get_value(&mut builder, inst.operands[1]);
                             let src2 = Self::get_value(&mut builder, inst.operands[2]);
                             let carry = Self::flag_value(&mut builder, Flag::C);
-                            let carry = builder.not(carry, I1);
+                            let carry = builder.bitwise_not(carry, I1);
                             let (dst_reg, sz) = Self::get_dst_reg(&builder, inst);
                             let op_type = helper::get_type_by_sizecode(sz);
                             let val = builder.sub(src1, src2, op_type);
@@ -892,14 +863,10 @@ impl Lifter for AArch64Lifter {
                             }
                         }
                         Opcode::SBFM => {
-                            let positive_condition_block = builder.create_block(
-                                "sbfm_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "sbfm_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("sbfm_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("sbfm_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -955,7 +922,7 @@ impl Lifter for AArch64Lifter {
                             let zero = builder.iconst(0);
                             let trap =
                                 builder.icmp(tnj::types::cmp::CmpTy::Eq, src2, zero, op_type);
-                            builder.trapif(trap, op_type);
+                            builder.trapif(trap);
                             let val = builder.idiv(src1, src2, op_type);
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                         }
@@ -1048,7 +1015,7 @@ impl Lifter for AArch64Lifter {
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                             if inst.opcode == Opcode::SUBS {
                                 let one = builder.iconst(1);
-                                let not_src2 = builder.not(src2, op_type).into();
+                                let not_src2 = builder.bitwise_not(src2, op_type).into();
                                 Self::set_flags_using_adc(
                                     &mut builder,
                                     src1,
@@ -1103,14 +1070,10 @@ impl Lifter for AArch64Lifter {
                             builder.jumpif(cmp, jump_block, Vec::new(), next_block, Vec::new());
                         }
                         Opcode::UBFM => {
-                            let positive_condition_block = builder.create_block(
-                                "ubfm_positive_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
-                            let negative_condition_block = builder.create_block(
-                                "ubfm_negative_condition",
-                                Vec::<BlockParamData>::new(),
-                            );
+                            let positive_condition_block =
+                                builder.create_block("ubfm_positive_condition", []);
+                            let negative_condition_block =
+                                builder.create_block("ubfm_negative_condition", []);
                             let next_address = pc + INSTRUCTION_SIZE;
                             let next_block = *label_resolver.get_block_by_address(next_address);
 
@@ -1169,7 +1132,7 @@ impl Lifter for AArch64Lifter {
                             let zero = builder.iconst(0);
                             let trap =
                                 builder.icmp(tnj::types::cmp::CmpTy::Eq, src2, zero, op_type);
-                            builder.trapif(trap, op_type);
+                            builder.trapif(trap);
                             let val = builder.udiv(src1, src2, op_type);
                             Self::write_reg(&mut builder, val, dst_reg, op_type);
                         }

--- a/tests/lifter/adrp.rs
+++ b/tests/lifter/adrp.rs
@@ -8,7 +8,7 @@ fn test_adrp_1() {
     ];
     let directives = r#"
         check: // entry block
-        nextln: v37 = i64.not 0xfff
+        nextln: v37 = i64.bitwise_not 0xfff
         nextln: v38 = i64.read_reg "pc"
         nextln: v39 = i64.and v38, v37
         nextln: v40 = i64.add v39, 0x0
@@ -25,7 +25,7 @@ fn test_adrp_2() {
     ];
     let directives = r#"
         check: // entry block
-        nextln: v37 = i64.not 0xfff
+        nextln: v37 = i64.bitwise_not 0xfff
         nextln: v38 = i64.read_reg "pc"
         nextln: v39 = i64.and v38, v37
         nextln: v40 = i64.add v39, 0x1000

--- a/tests/lifter/bfm.rs
+++ b/tests/lifter/bfm.rs
@@ -21,7 +21,7 @@ fn test_bfm_1() {
         # nextln:   v45 = i32.lshr v44, 0xc
         # nextln:   v46 = i32.lshl 0x1, v40
         # nextln:   v47 = i32.sub v46, 0x1
-        # nextln:   v48 = i32.not v47
+        # nextln:   v48 = i32.bitwise_not v47
         # nextln:   v49 = i32.and v37, v48
         # nextln:   v50 = i32.or v45, v49
         # nextln:   i32.write_reg v50, "x1"
@@ -36,7 +36,7 @@ fn test_bfm_1() {
         # nextln:   v57 = i32.lshl 0x1, v51
         # nextln:   v58 = i32.sub v57, 0x1
         # nextln:   v59 = i32.lshl v58, v55
-        # nextln:   v60 = i32.not v59
+        # nextln:   v60 = i32.bitwise_not v59
         # nextln:   v61 = i32.and v37, v60
         # nextln:   v62 = i32.or v56, v61
         # nextln:   i32.write_reg v62, "x1"
@@ -66,7 +66,7 @@ fn test_bfm_2() {
         # nextln:   v45 = i64.lshr v44, 0x1
         # nextln:   v46 = i64.lshl 0x1, v40
         # nextln:   v47 = i64.sub v46, 0x1
-        # nextln:   v48 = i64.not v47
+        # nextln:   v48 = i64.bitwise_not v47
         # nextln:   v49 = i64.and v37, v48
         # nextln:   v50 = i64.or v45, v49
         # nextln:   i64.write_reg v50, "x1"
@@ -81,7 +81,7 @@ fn test_bfm_2() {
         # nextln:   v57 = i64.lshl 0x1, v51
         # nextln:   v58 = i64.sub v57, 0x1
         # nextln:   v59 = i64.lshl v58, v55
-        # nextln:   v60 = i64.not v59
+        # nextln:   v60 = i64.bitwise_not v59
         # nextln:   v61 = i64.and v37, v60
         # nextln:   v62 = i64.or v56, v61
         # nextln:   i64.write_reg v62, "x1"
@@ -110,7 +110,7 @@ fn test_bfm_3() {
         nextln:   v45 = i64.lshr v44, 0x2
         nextln:   v46 = i64.lshl 0x1, v40
         nextln:   v47 = i64.sub v46, 0x1
-        nextln:   v48 = i64.not v47
+        nextln:   v48 = i64.bitwise_not v47
         nextln:   v49 = i64.and v37, v48
         nextln:   v50 = i64.or v45, v49
         nextln:   i64.write_reg v50, "x1"
@@ -125,7 +125,7 @@ fn test_bfm_3() {
         nextln:   v57 = i64.lshl 0x1, v51
         nextln:   v58 = i64.sub v57, 0x1
         nextln:   v59 = i64.lshl v58, v55
-        nextln:   v60 = i64.not v59
+        nextln:   v60 = i64.bitwise_not v59
         nextln:   v61 = i64.and v37, v60
         nextln:   v62 = i64.or v56, v61
         nextln:   i64.write_reg v62, "x1"

--- a/tests/lifter/bic.rs
+++ b/tests/lifter/bic.rs
@@ -11,7 +11,7 @@ fn test_bic_1() {
         nextln: v37 = i32.read_reg "x2"
         nextln: v38 = i32.read_reg "x3"
         nextln: v39 = i32.lshl v38, 0x2
-        nextln: v40 = i32.not v39
+        nextln: v40 = i32.bitwise_not v39
         nextln: v41 = i32.and v37, v40
         nextln: i32.write_reg v41, "x1"
     "#;
@@ -29,7 +29,7 @@ fn test_bic_2() {
         nextln: v37 = i64.read_reg "x2"
         nextln: v38 = i64.read_reg "x3"
         nextln: v39 = i64.lshl v38, 0x3
-        nextln: v40 = i64.not v39
+        nextln: v40 = i64.bitwise_not v39
         nextln: v41 = i64.and v37, v40
         nextln: i64.write_reg v41, "x1"
     "#;
@@ -47,7 +47,7 @@ fn test_bic_3() {
         nextln: v37 = i64.read_reg "x2"
         nextln: v38 = i64.read_reg "x3"
         nextln: v39 = i64.ashr v38, 0x1
-        nextln: v40 = i64.not v39
+        nextln: v40 = i64.bitwise_not v39
         nextln: v41 = i64.and v37, v40
         nextln: i64.write_reg v41, "x1"
     "#;

--- a/tests/lifter/ccmp.rs
+++ b/tests/lifter/ccmp.rs
@@ -14,7 +14,7 @@ fn test_ccmp_1() {
         check: ccmp_positive_condition:
         nextln:   v39 = i64.read_reg "x0"
         nextln:   v40 = i64.read_reg "x1"
-        nextln:   v41 = i64.not v40
+        nextln:   v41 = i64.bitwise_not v40
         nextln:   v42 = i64.add v39, v41
         nextln:   v43 = i64.add v42, 0x0
         nextln:   v44 = i64.icmp.eq v43, 0x0
@@ -64,7 +64,7 @@ fn test_ccmp_2() {
         check: ccmp_positive_condition:
         nextln:   v39 = i32.read_reg "x0"
         nextln:   v40 = i32.read_reg "x2"
-        nextln:   v41 = i32.not v40
+        nextln:   v41 = i32.bitwise_not v40
         nextln:   v42 = i32.add v39, v41
         nextln:   v43 = i32.add v42, 0x0
         nextln:   v44 = i32.icmp.eq v43, 0x0
@@ -113,7 +113,7 @@ fn test_ccmp_3() {
         check: ccmp_positive_condition:
         nextln:   v38 = i64.read_reg "x6"
         nextln:   v39 = i64.read_reg "x6"
-        nextln:   v40 = i64.not v39
+        nextln:   v40 = i64.bitwise_not v39
         nextln:   v41 = i64.add v38, v40
         nextln:   v42 = i64.add v41, 0x0
         nextln:   v43 = i64.icmp.eq v42, 0x0

--- a/tests/lifter/cls.rs
+++ b/tests/lifter/cls.rs
@@ -11,7 +11,7 @@ fn test_cls_1() {
         nextln: v37 = i64.read_reg "x2"
         nextln: v38 = i64.lshr v37, 0x1
         nextln: v39 = i64.ror 0x1, 0x1
-        nextln: v40 = i64.not v39
+        nextln: v40 = i64.bitwise_not v39
         nextln: v41 = i64.and v40, v37
         nextln: v42 = i64.xor v38, v41
         nextln: v43 = i64.highest_set_bit v42
@@ -33,7 +33,7 @@ fn test_cls_2() {
         nextln: v37 = i32.read_reg "x2"
         nextln: v38 = i32.lshr v37, 0x1
         nextln: v39 = i32.ror 0x1, 0x1
-        nextln: v40 = i32.not v39
+        nextln: v40 = i32.bitwise_not v39
         nextln: v41 = i32.and v40, v37
         nextln: v42 = i32.xor v38, v41
         nextln: v43 = i32.highest_set_bit v42

--- a/tests/lifter/csinv.rs
+++ b/tests/lifter/csinv.rs
@@ -18,7 +18,7 @@ fn test_csinv_1() {
         nextln:   jump $LABEL
         check: csinv_negative_condition:
         nextln:   $VAR_NAME = i32.read_reg "x3"
-        nextln:   $VAR_NAME = i32.not $VAR_NAME 
+        nextln:   $VAR_NAME = i32.bitwise_not $VAR_NAME
         nextln:   i32.write_reg $VAR_NAME, "x1"
         nextln:   jump $LABEL
     "#;
@@ -43,7 +43,7 @@ fn test_csinv_2() {
         nextln:   jump $LABEL
         check: csinv_negative_condition:
         nextln:   $VAR_NAME = i64.read_reg "x3"
-        nextln:   $VAR_NAME = i64.not $VAR_NAME
+        nextln:   $VAR_NAME = i64.bitwise_not $VAR_NAME
         nextln:   i64.write_reg $VAR_NAME, "x1"
         nextln:   jump $LABEL
     "#;
@@ -67,7 +67,7 @@ fn test_csinv_3() {
         nextln:   jump $LABEL
         check: csinv_negative_condition:
         nextln:   v40 = i64.read_reg "x2"
-        nextln:   v41 = i64.not v40
+        nextln:   v41 = i64.bitwise_not v40
         nextln:   i64.write_reg v41, "x1"
         nextln:   jump $LABEL
     "#;

--- a/tests/lifter/eon.rs
+++ b/tests/lifter/eon.rs
@@ -11,7 +11,7 @@ fn test_eon_1() {
         nextln:  v37 = i64.read_reg "x2"
         nextln:  v38 = i64.read_reg "x3"
         nextln:  v39 = i64.lshr v38, 0xc
-        nextln:  v40 = i64.not v39
+        nextln:  v40 = i64.bitwise_not v39
         nextln:  v41 = i64.xor v37, v40
         nextln:  i64.write_reg v41, "x1"
     "#;
@@ -29,7 +29,7 @@ fn test_eon_2() {
         nextln:  v37 = i64.read_reg "x2"
         nextln:  v38 = i64.read_reg "x3"
         nextln:  v39 = i64.ashr v38, 0x1
-        nextln:  v40 = i64.not v39
+        nextln:  v40 = i64.bitwise_not v39
         nextln:  v41 = i64.xor v37, v40
         nextln:  i64.write_reg v41, "x1"
     "#;
@@ -47,7 +47,7 @@ fn test_eon_3() {
         nextln:  v37 = i32.read_reg "x2"
         nextln:  v38 = i32.read_reg "x3"
         nextln:  v39 = i32.ashr v38, 0x1
-        nextln:  v40 = i32.not v39
+        nextln:  v40 = i32.bitwise_not v39
         nextln:  v41 = i32.xor v37, v40
         nextln:  i32.write_reg v41, "x1"
     "#;

--- a/tests/lifter/movn.rs
+++ b/tests/lifter/movn.rs
@@ -8,7 +8,7 @@ fn test_movn_1() {
     let directives = r#"
         check: // entry block
         nextln: i32.write_reg 0x0, "x1"
-        nextln: v37 = i16.not 0xc0000
+        nextln: v37 = i16.bitwise_not 0xc0000
         nextln: i16.write_reg v37, "x1"
     "#;
 
@@ -23,7 +23,7 @@ fn test_movn_2() {
     let directives = r#"
         check: // entry block
         nextln:  i64.write_reg 0x0, "x1"
-        nextln:  v37 = i16.not 0xd
+        nextln:  v37 = i16.bitwise_not 0xd
         nextln:  i16.write_reg v37, "x1"
     "#;
 

--- a/tests/lifter/orn.rs
+++ b/tests/lifter/orn.rs
@@ -11,7 +11,7 @@ fn test_and_1() {
         nextln:  v37 = i32.read_reg "x1"
         nextln:  v38 = i32.read_reg "x2"
         nextln:  v39 = i32.lshl v38, 0x3
-        nextln:  v40 = i32.not v39
+        nextln:  v40 = i32.bitwise_not v39
         nextln:  v41 = i32.or v37, v40
         nextln:  i32.write_reg v41, "x0"
     "#;
@@ -28,7 +28,7 @@ fn test_and_2() {
         check: // entry block
         nextln:  v37 = i64.read_reg "x2"
         nextln:  v38 = i64.read_reg "x1"
-        nextln:  v39 = i64.not v38
+        nextln:  v39 = i64.bitwise_not v38
         nextln:  v40 = i64.or v37, v39
         nextln:  i64.write_reg v40, "x1"
     "#;
@@ -46,7 +46,7 @@ fn test_orn_3() {
         nextln:  v37 = i64.read_reg "x1"
         nextln:  v38 = i64.read_reg "x2"
         nextln:  v39 = i64.lshl v38, 0x4
-        nextln:  v40 = i64.not v39
+        nextln:  v40 = i64.bitwise_not v39
         nextln:  v41 = i64.or v37, v40
         nextln:  i64.write_reg v41, "x0"
     "#;

--- a/tests/lifter/sbc.rs
+++ b/tests/lifter/sbc.rs
@@ -10,7 +10,7 @@ fn test_sbc_1() {
         nextln: v37 = i32.read_reg "x2"
         nextln: v38 = i32.read_reg "x3"
         nextln: v39 = i1.read_reg "c"
-        nextln: v40 = i1.not v39
+        nextln: v40 = i1.bitwise_not v39
         nextln: v41 = i32.sub v37, v38
         nextln: v42 = i32.sub v41, v40
         nextln: i32.write_reg v42, "x1"
@@ -29,7 +29,7 @@ fn test_sbc_2() {
         nextln: v37 = i64.read_reg "x2"
         nextln: v38 = i64.read_reg "x3"
         nextln: v39 = i1.read_reg "c"
-        nextln: v40 = i1.not v39
+        nextln: v40 = i1.bitwise_not v39
         nextln: v41 = i64.sub v37, v38
         nextln: v42 = i64.sub v41, v40
         nextln: i64.write_reg v42, "x1"

--- a/tests/lifter/sbcs.rs
+++ b/tests/lifter/sbcs.rs
@@ -10,7 +10,7 @@ fn test_sbcs_1() {
         nextln: v37 = i32.read_reg "x2"
         nextln: v38 = i32.read_reg "x3"
         nextln: v39 = i1.read_reg "c"
-        nextln: v40 = i1.not v39
+        nextln: v40 = i1.bitwise_not v39
         nextln: v41 = i32.sub v37, v38
         nextln: v42 = i32.sub v41, v40
         nextln: i32.write_reg v42, "x1"
@@ -46,7 +46,7 @@ fn test_sbcs_2() {
         nextln: v37 = i64.read_reg "x2"
         nextln: v38 = i64.read_reg "x3"
         nextln: v39 = i1.read_reg "c"
-        nextln: v40 = i1.not v39
+        nextln: v40 = i1.bitwise_not v39
         nextln: v41 = i64.sub v37, v38
         nextln: v42 = i64.sub v41, v40
         nextln: i64.write_reg v42, "x1"

--- a/tests/lifter/sdiv.rs
+++ b/tests/lifter/sdiv.rs
@@ -11,9 +11,9 @@ fn test_sdiv_1() {
         nextln: v37 = i64.read_reg "x1"
         nextln: v38 = i64.read_reg "x2"
         nextln: v39 = i64.icmp.eq v38, 0x0
-        nextln: v40 = i64.trapif v39
-        nextln: v41 = i64.idiv v37, v38
-        nextln: i64.write_reg v41, "x0"
+        nextln: trapif v39
+        nextln: v40 = i64.idiv v37, v38
+        nextln: i64.write_reg v40, "x0"
     "#;
 
     check_instruction(bytes, directives, CheckInstructionArgs::default());
@@ -29,9 +29,9 @@ fn test_sdiv_2() {
         nextln: v37 = i32.read_reg "x1"
         nextln: v38 = i32.read_reg "x2"
         nextln: v39 = i32.icmp.eq v38, 0x0
-        nextln: v40 = i32.trapif v39
-        nextln: v41 = i32.idiv v37, v38
-        nextln: i32.write_reg v41, "x0"
+        nextln: trapif v39
+        nextln: v40 = i32.idiv v37, v38
+        nextln: i32.write_reg v40, "x0"
     "#;
 
     check_instruction(bytes, directives, CheckInstructionArgs::default());

--- a/tests/lifter/subs.rs
+++ b/tests/lifter/subs.rs
@@ -11,7 +11,7 @@ fn test_subs_1() {
         nextln:  v38 = i64.read_reg "x0"
         nextln:  v39 = i64.sub v37, v38
         nextln:  i64.write_reg v39, "x1"
-        nextln:  v40 = i64.not v38
+        nextln:  v40 = i64.bitwise_not v38
         nextln:  v41 = i64.add v37, v40
         nextln:  v42 = i64.add v41, 0x1
         nextln:  v43 = i64.icmp.eq v42, 0x0
@@ -44,7 +44,7 @@ fn test_subs_2() {
         nextln:  v38 = i32.read_reg "x0"
         nextln:  v39 = i32.sub v37, v38
         nextln:  i32.write_reg v39, "x1"
-        nextln:  v40 = i32.not v38
+        nextln:  v40 = i32.bitwise_not v38
         nextln:  v41 = i32.add v37, v40
         nextln:  v42 = i32.add v41, 0x1
         nextln:  v43 = i32.icmp.eq v42, 0x0

--- a/tests/lifter/udiv.rs
+++ b/tests/lifter/udiv.rs
@@ -10,9 +10,9 @@ fn test_udiv_1() {
         nextln: v37 = i32.read_reg "x2"
         nextln: v38 = i32.read_reg "x3"
         nextln: v39 = i32.icmp.eq v38, 0x0
-        nextln: v40 = i32.trapif v39
-        nextln: v41 = i32.udiv v37, v38
-        nextln: i32.write_reg v41, "x1"
+        nextln: trapif v39
+        nextln: v40 = i32.udiv v37, v38
+        nextln: i32.write_reg v40, "x1"
     "#;
 
     check_instruction(bytes, directives, CheckInstructionArgs::default());
@@ -28,9 +28,9 @@ fn test_udiv_2() {
         nextln: v37 = i64.read_reg "x2"
         nextln: v38 = i64.read_reg "x3"
         nextln: v39 = i64.icmp.eq v38, 0x0
-        nextln: v40 = i64.trapif v39
-        nextln: v41 = i64.udiv v37, v38
-        nextln: i64.write_reg v41, "x1"
+        nextln: trapif v39
+        nextln: v40 = i64.udiv v37, v38
+        nextln: i64.write_reg v40, "x1"
     "#;
 
     check_instruction(bytes, directives, CheckInstructionArgs::default());


### PR DESCRIPTION
I've broken a few things here with my latest upstream changes in tnj. This PR fixes these.

Note: By removing the hardcoded reference to tnj and replacing it with just a reference to master (with the exact ref being in specified in `Cargo.lock`) it is easier for downstream users to use both this and the tnj repo in their project.
When you want to update, just run `cargo update`. It will update `Cargo.lock`.